### PR TITLE
Fixes Shuttle Runtimes + Decal Coloring Issue

### DIFF
--- a/code/datums/elements/decals/_decal.dm
+++ b/code/datums/elements/decals/_decal.dm
@@ -106,7 +106,7 @@
  * all args are fed into creating an image, they are byond vars for images you'll recognize in the byond docs
  * (except source, source is the object whose appearance we're copying.)
  */
-/datum/element/decal/proc/generate_appearance(_icon, _icon_state, _dir, _plane, _layer, _color, _alpha, _smoothing, source)
+/datum/element/decal/proc/generate_appearance(_icon, _icon_state, _dir, _plane, _layer, _color, _alpha, _smoothing, source, _appearance_flags = RESET_COLOR)
 	if(!_icon || !_icon_state)
 		return FALSE
 	var/temp_image = image(_icon, null, isnull(_smoothing) ? _icon_state : "[_icon_state]-[_smoothing]", _layer, _dir)
@@ -114,6 +114,7 @@
 	pic.plane = _plane
 	pic.color = _color
 	pic.alpha = _alpha
+	pic.appearance_flags = _appearance_flags
 	return TRUE
 
 /datum/element/decal/Detach(atom/source)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -99,10 +99,16 @@ GLOBAL_LIST_EMPTY(station_turfs)
 
 	set_light(0)
 
-	if(base_color || paint_color)
-		color = paint_color ? paint_color : base_color
+	remove_atom_colour(FIXED_COLOUR_PRIORITY)
+	remove_atom_colour(WASHABLE_COLOUR_PRIORITY)
 
-	//readd overlays
+	if(base_color && !paint_color)
+		add_atom_colour(base_color, FIXED_COLOUR_PRIORITY)
+
+	if(paint_color)
+		add_atom_colour(paint_color, WASHABLE_COLOUR_PRIORITY)
+
+//readd overlays
 	if(pattern_type && pattern_color)
 		. += mutable_appearance(pattern_type, "[smoothing_junction]", appearance_flags = RESET_COLOR, alpha = 255, color = pattern_color)
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -96,23 +96,19 @@ GLOBAL_LIST_EMPTY(station_turfs)
 
 /turf/update_overlays()
 	. = ..()
-	if(color)
-		base_color = color
-		color = null
 
 	set_light(0)
 
 	if(base_color || paint_color)
-		var/applied_color = (paint_color ? paint_color : base_color)
-		. += mutable_appearance(icon, icon_state, alpha = 200, color = applied_color)
+		color = paint_color ? paint_color : base_color
 
 	//readd overlays
 	if(pattern_type && pattern_color)
-		. += mutable_appearance(pattern_type, "[smoothing_junction]", alpha = 255, color = pattern_color)
+		. += mutable_appearance(pattern_type, "[smoothing_junction]", appearance_flags = RESET_COLOR, alpha = 255, color = pattern_color)
 
 		if(pattern_glow)
 			set_light(2,2, pattern_color)
-			. += emissive_appearance(pattern_type, "[smoothing_junction]", alpha = 255)
+			. += emissive_appearance(pattern_type, "[smoothing_junction]", appearance_flags = RESET_COLOR, alpha = 255)
 
 /**
  * Turf Initialize
@@ -135,6 +131,9 @@ GLOBAL_LIST_EMPTY(station_turfs)
 	assemble_baseturfs()
 
 	levelupdate()
+
+	if(color)
+		base_color = color
 
 	if (length(smoothing_groups))
 		sortTim(smoothing_groups) //In case it's not properly ordered, let's avoid duplicate entries with the same values.
@@ -184,6 +183,7 @@ GLOBAL_LIST_EMPTY(station_turfs)
 			armor = getArmor(arglist(armor))
 		else if (!armor)
 			armor = getArmor()
+
 
 	return INITIALIZE_HINT_NORMAL
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Shuttles launching and leaving would leave errors and runtimes with a base color turf. To get rid of this problem, colors now use the add_atom_color function as they should.

Shuttles should work fine now. Decals did not show correctly on colored flooring. This now fixes the issue.

## Why It's Good For The Game

Fixes appearance of turfs and decals.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixes shuttle runtimes and issues with decal coloring.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
